### PR TITLE
Improve implementation of get_management_info function

### DIFF
--- a/pylontech/pylontech.py
+++ b/pylontech/pylontech.py
@@ -63,19 +63,31 @@ class Pylontech:
     )
 
     management_info_fmt = construct.Struct(
-        "CommandValue" / construct.Byte,
-        "ChargeVoltageLimit" / construct.Array(2, construct.Byte),
-        "DischargeVoltageLimit" / construct.Array(2, construct.Byte),
-        "ChargeCurrentLimit" / construct.Array(2, construct.Byte),
-        "DishargeCurrentLimit" / construct.Array(2, construct.Byte),
-        "Status" / construct.Byte,
+        "ChargeVoltageLimit" / DivideBy1000(construct.Int16sb),
+        "DischargeVoltageLimit" / DivideBy1000(construct.Int16sb),
+        "ChargeCurrentLimit" / ToAmp(construct.Int16sb),
+        "DischargeCurrentLimit" / ToAmp(construct.Int16sb),
+        "status"
+        / construct.BitStruct(
+            "ChargeEnable" / construct.Flag,
+            "DischargeEnable" / construct.Flag,
+            "ChargeImmediately2" / construct.Flag,
+            "ChargeImmediately1" / construct.Flag,
+            "FullChargeRequest" / construct.Flag,
+            "ShouldCharge"
+            / construct.Computed(
+                lambda this: this.ChargeImmediately2
+                | this.ChargeImmediately1
+                | this.FullChargeRequest
+            ),
+            "_padding" / construct.BitsInteger(3),
+        ),
     )
 
     module_serial_number_fmt = construct.Struct(
         "CommandValue" / construct.Byte,
         "ModuleSerialNumber" / JoinBytes(construct.Array(16, construct.Byte)),
     )
-
 
     get_values_fmt = construct.Struct(
         "NumberOfModules" / construct.Byte,
@@ -243,14 +255,14 @@ class Pylontech:
         f = self.read_frame()
         return self.system_parameters_fmt.parse(f.info[1:])
 
-    def get_management_info(self):
-        raise Exception('Dont touch this for now')
-        self.send_cmd(2, 0x92)
+    def get_management_info(self, dev_id):
+        bdevid = "{:02X}".format(dev_id).encode()
+        self.send_cmd(dev_id, 0x92, bdevid)
         f = self.read_frame()
 
         print(f.info)
         print(len(f.info))
-        ff = self.management_info_fmt.parse(f.info)
+        ff = self.management_info_fmt.parse(f.info[1:])
         print(ff)
         return ff
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -382,28 +382,16 @@ def test_up2500_1module_status_info_parsing_1():
 
 def test_up2500_management_info():
     p = Pylontech([b"~20024600B014026EF05AA0022BFDD5C0F915\r"])
-    p.send_cmd(2, 0x92, b"02")
 
-    mgmt = construct.Struct(
-        "ChargeVoltageLimit" / DivideBy1000(construct.Int16sb),
-        "DischargeVoltageLimit" / DivideBy1000(construct.Int16sb),
-        "ChargeCurrentLimit" / ToAmp(construct.Int16sb),
-        "DischargeCurrentLimit" / ToAmp(construct.Int16sb),
-        "status"
-        / construct.BitStruct(
-            "ChargeEnable" / construct.Flag,
-            "DischargeEnable" / construct.Flag,
-            "ChargeImmediately2" / construct.Flag,
-            "ChargeImmediately1" / construct.Flag,
-            "FullChargeRequest" / construct.Flag,
-            "ShouldCharge"
-            / construct.Computed(
-                lambda this: this.ChargeImmediately2
-                | this.ChargeImmediately1
-                | this.FullChargeRequest
-            ),
-            "_padding" / construct.BitsInteger(3),
-        ),
-    )
-    f = p.read_frame()
-    print(mgmt.parse(f.info[1:]))
+    d = p.get_management_info(2)
+
+    assert d.ChargeVoltageLimit == 28.4
+    assert d.DischargeVoltageLimit == 23.2
+    assert d.ChargeCurrentLimit == 55.5
+    assert d.DischargeCurrentLimit == -55.5
+    assert d.status.ChargeEnable
+    assert d.status.DischargeEnable
+    assert not d.status.ChargeImmediately2
+    assert not d.status.ChargeImmediately1
+    assert not d.status.FullChargeRequest
+    assert not d.status.ShouldCharge


### PR DESCRIPTION
Hi! 

I've hacked a bit further and I think the get_management_info message seem to work for me now, so we can see when the battery requests charging and when it allows charging / discharging - which could be used for inverter control. 

Please let me know if you think this looks right or if there's any comments or concerns :) 